### PR TITLE
QT Open dialog doesn't work on Linux

### DIFF
--- a/mDrawGui/robot_gui.py
+++ b/mDrawGui/robot_gui.py
@@ -337,7 +337,7 @@ class MainUI(QtGui.QWidget):
     def loadPic(self,filename=False):
         self.clearPic()
         if filename==False:
-            filename = str(QtGui.QFileDialog.getOpenFileName(self, 'Open Svg/Bmp', '', ".svg;.bmp(*.svg;*.bmp)").toUtf8())
+            filename = str(QtGui.QFileDialog.getOpenFileName(self, 'Open Svg/Bmp', '', ".svg .bmp (*.svg *.bmp)").toUtf8())
         self.dbg(filename)
         if len(filename)==0:
             return


### PR DESCRIPTION
Invalid usage of ; according to:
http://pyqt.sourceforge.net/Docs/PyQt4/qfiledialog.html#getOpenFileName

Fixes issue #7 could you please test this on OS X / Windows?
