### PR TITLE
glibc fixes

### DIFF
--- a/firmwares/xybot/xybot.ino
+++ b/firmwares/xybot/xybot.ino
@@ -217,6 +217,7 @@ void parseCordinate(char * cmd)
   tarY = curY;
   while(str!=NULL){
     str = strtok_r(0, " ", &tmp);
+    if (str==NULL) break;
     if(str[0]=='X'){
       tarX = atof(str+1);
     }else if(str[0]=='Y'){


### PR DESCRIPTION
I don't know how this can work on the Arduino. strtok_r returns a null pointer if there are no more tokens and str[0] seems to be poking around in that null pointer.
