### PR TITLE
Fix a svg parse issue

### DIFF
--- a/mDrawGui/SvgParser.py
+++ b/mDrawGui/SvgParser.py
@@ -264,8 +264,8 @@ class SvgParser():
         d = node.getAttribute("d")
         ds = d.replace("e-","ee")
         ds=ds.replace("-"," -").replace("s", " s ").replace("S", " S ").replace("c", " c ").replace("C", " C ").replace("v", " v ").replace("V", " V ")
-        ds=ds.replace("l", " l ").replace("L"," L ").replace("A", " A ").replace("a", " a ").replace(",", " ").replace("M", "M ").replace("h", " h ").replace("H", " H ").replace("m"," m ").replace('z',' z ')
-        ds=ds.replace("q", " q ").replace("Q", " Q ")
+        ds=ds.replace("l", " l ").replace("L"," L ").replace("A", " A ").replace("a", " a ").replace(",", " ").replace("M", "M ").replace("h", " h ").replace("H", " H ").replace("m"," m ").replace("z"," z ")
+        ds=ds.replace("q", " q ").replace("Q", " Q ").replace("Z"," Z ")
         ss=ds.split()
         for i in range(len(ss)):
             ss[i] = ss[i].replace("ee","e-")

--- a/mDrawGui/mDraw.py
+++ b/mDrawGui/mDraw.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 import sys
 import os
 import threading


### PR DESCRIPTION
Fix a cash issue on certain svg files where the svg path description ends with a capital Z

A trailing 'Z' in the svg path description leads to qt crash, cause of a missing replacement command.